### PR TITLE
Enable OneGate token on VMs

### DIFF
--- a/tf-modules/tf-module-hypercloud-node/main.tf
+++ b/tf-modules/tf-module-hypercloud-node/main.tf
@@ -24,6 +24,7 @@ resource "opennebula_virtual_machine" "instance" {
     SSH_PUBLIC_KEY = var.ssh_key
     NETWORK      = "YES"
     SET_HOSTNAME = "$NAME"
+    TOKEN        = "YES"
   }
 
   os {


### PR DESCRIPTION
This is useful so that VMs know which VMID they have