### PR TITLE
Terraform Provider update & VM scheduling fix

### DIFF
--- a/k3s/terraform/provider.tf
+++ b/k3s/terraform/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     opennebula = {
       source = "OpenNebula/opennebula"
-      version = "0.5.2"
+      version = "1.2.1"
     }
   }
 }

--- a/tf-modules/tf-module-hypercloud-node/main.tf
+++ b/tf-modules/tf-module-hypercloud-node/main.tf
@@ -58,4 +58,6 @@ resource "opennebula_virtual_machine" "instance" {
       security_groups = nic.value["net_sgs"]
     }
   }
+
+  sched_requirements = "(ARCH = \"x86_64\") & (HYPERVISOR = \"kvm\")"
 }


### PR DESCRIPTION
Update Terraform provider to support insecure connections on testing hardware and prevent x86 VMs being scheduled to aarch64 nodes.